### PR TITLE
composable install with oidc endpoint discovery

### DIFF
--- a/uninstall_using_composable.sh
+++ b/uninstall_using_composable.sh
@@ -14,7 +14,7 @@ oc delete OidcClientRegistration turbonomic-oidc-registration -n ${NS}
 oc delete Subscription t8c-certified -n ${NS}
 oc delete Subscription composable-operator -n ${NS}
 oc delete ClusterServiceVersion composable-operator.v0.1.3 -n ${NS}
-oc delete ClusterServiceVersion t8c-operator.v8.1.0 -n ${NS}
+oc delete ClusterServiceVersion t8c-operator.v42.6.0 -n ${NS}
 
 # Let the user delete the project afterwards
 #oc delete ns ${NS}


### PR DESCRIPTION
After modify the platform-auth-idp configmap, the oidc discovery works correctly

```
$  oc get cm platform-auth-idp  -o yaml|grep URL
  OIDC_ISSUER_URL: [https://cp-console.apps.yellow-22.dev.multicloudops.io:443/idauth/oidc/endpoint/OP](https://cp-console.apps.yellow-22.dev.multicloudops.io/idauth/oidc/endpoint/OP)
  PROVIDER_ISSUER_URL: [https://cp-console.apps.yellow-22.dev.multicloudops.io:443/idprovider/v1/auth](https://cp-console.apps.yellow-22.dev.multicloudops.io/idprovider/v1/auth)
````